### PR TITLE
Factoryパターンの学習として、各ファイルを作成。

### DIFF
--- a/tmp/factory2/AbstractDatabaseModelFactory.php
+++ b/tmp/factory2/AbstractDatabaseModelFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication;
+
+// 一旦、UserModelInterface,BlogModelInterfaceを使用します。
+use MyApplication\Models\UserModelInterface;
+use MyApplication\Models\BlogModelInterface;
+// use MyApplication\Models\FriendModelInterface;
+// use MyApplication\Models\BlogCategoryInterface;
+
+abstract class AbstractDatabaseModelFactory
+{
+  // 一旦、createUserModel(),createBlogModel()を定義します。
+  abstract public function createUserModel(): UserModelInterface;
+  abstract public function createBlogModel(): BlogModelInterface;
+  // abstract public function createBlogCategoryModel(): BlogCategoryModelInterface;
+  // abstract public function createFriendModel(): FriendModelInterface;
+}

--- a/tmp/factory2/BlogController.php
+++ b/tmp/factory2/BlogController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication;
+
+require_once dirname(__FILE__) . '/DatabaseModelFactory.php';
+require_once dirname(__FILE__) . '/TestDatabaseModelFactory.php';
+
+
+// ブログページを表示するクラス
+
+class BlogController
+{
+  // DatabaseModelFactoryインスタンス
+  private $modelFactory;
+
+  // コンストラクタ
+  public function __construct(bool $isTesting = false)
+  {
+    if ($isTesting) {
+      $this->modelFactory = new TestDatabaseModelFactory();
+    } else {
+      $this->modelFactory = new DatabaseModelFactory();
+    }
+  }
+
+  // ブログ記事ページを表示する
+  public function show(int $userId, int $blogId): void
+  {
+    // ユーザー情報を取得する
+    $user = $this->modelFactory->createUserModel()->find($userId);
+
+    // ブログ記事を取得する。一旦非実装
+    $blog = $this->modelFactory->createBlogModel()->find($blogId);
+
+    // ブログ記事を表示する処理を今後実装
+    echo $user . PHP_EOL;
+    echo $blog . PHP_EOL;
+  }
+}
+
+// メインルーチン
+$controller = new BlogController(true);
+$controller->show(1001, 2001);

--- a/tmp/factory2/DatabaseModelFactory.php
+++ b/tmp/factory2/DatabaseModelFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication;
+
+// 一旦、UserModel,BlogModelを使用します。
+use MyApplication\Models\UserModelInterface;
+use MyApplication\Models\BlogModelInterface;
+// use MyApplication\Models\FriendModelInterface;
+// use MyApplication\Models\BlogCategoryModelInterface;
+use MyApplication\Models\Production\UserModel;
+use MyApplication\Models\Production\BlogModel;
+// use MyApplication\Models\Production\FriendModel;
+// use MyApplication\Models\Production\BlogCategoryModel;
+require_once dirname(__FILE__) . '/AbstractDatabaseModelFactory.php';
+// 一旦、UserModel.php,BlogModel.phpを使用します。
+require_once dirname(__FILE__) . '/models/production/UserModel.php';
+require_once dirname(__FILE__) . '/models/production/BlogModel.php';
+// require_once dirname(__FILE__) . '/models/production/FriendModel.php';
+// require_once dirname(__FILE__) . '/models/production/BlogCategoryModel.php';
+
+// データベースに接続するモデルクラスのインスタンスを返すFactoryクラス
+class DatabaseModelFactory extends AbstractDatabaseModelFactory
+{
+  // UserModelインスタンスを返す。一旦このUserModelインスタンスのみ使用。
+  public function createUserModel(): UserModelInterface
+  {
+    return new UserModel();
+  }
+
+  // BlogModelインスタンスを返す
+  public function createBlogModel(): BlogModelInterface
+  {
+    return new BlogModel();
+  }
+
+  // FriendModelインスタンスを返す。
+  // public function createFriendModel(): FriendModelInterface
+  // {
+  //   return new FriendModel();
+  // }
+  // BlogCategoryModelインスタンスを返す
+  // public function createBlogCategoryModel(): BlogCategoryModelInterface
+  // {
+  //   return new BlogCategoryModel();
+  // }
+
+
+}

--- a/tmp/factory2/TestDatabaseModelFactory.php
+++ b/tmp/factory2/TestDatabaseModelFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication;
+
+// 一旦、UserModel,BlogModelを使用します。
+use MyApplication\Models\UserModelInterface;
+use MyApplication\Models\BlogModelInterface;
+// use MyApplication\Models\FriendModelInterface;
+// use MyApplication\Models\BlogCategoryModelInterface;
+use MyApplication\Models\Testing\TestUserModel;
+use MyApplication\Models\Testing\TestBlogModel;
+// use MyApplication\Models\Testing\FriendModel;
+// use MyApplication\Models\Testing\BlogCategoryModel;
+require_once dirname(__FILE__) . '/AbstractDatabaseModelFactory.php';
+// 一旦、UserModel.php,BlogModel.phpを使用します。
+require_once dirname(__FILE__)  . '/models/testing/TestUserModel.php';
+require_once dirname(__FILE__)  . '/models/testing/TestBlogModel.php';
+// require_once dirname(__FILE__) . '/models/testing/TestFriendModel.php';
+// require_once dirname(__FILE__) . '/models/testing/TestBlogCategoryModel.php';
+
+// テストデータ用モデルクラスのインスタンスを返すFactoryクラス
+class TestDatabaseModelFactory extends AbstractDatabaseModelFactory
+{
+  // UserModelインスタンスを返す。一旦このUserModelインスタンスのみ使用。
+  public function createUserModel(): UserModelInterface
+  {
+    return new TestUserModel();
+  }
+
+  // TestBlogModelインスタンスを返す
+  public function createBlogModel(): BlogModelInterface
+  {
+    return new TestBlogModel();
+  }
+
+  // TestFriendModelインスタンスを返す。
+  // public function createFriendModel(): FriendModelInterface
+  // {
+  //   return new TestFriendModel();
+  // }
+  // TestBlogCategoryModelインスタンスを返す
+  // public function createBlogCategoryModel(): BlogCategoryModelInterface
+  // {
+  //   return new TestaBlogCategoryModel();
+  // }
+
+
+}

--- a/tmp/factory2/models/BlogModelInterface.php
+++ b/tmp/factory2/models/BlogModelInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models;
+
+interface BlogModelInterface
+{
+  // ブログ記事の情報を取得する
+  public function find(int $blogId);
+}

--- a/tmp/factory2/models/UserModelInterface.php
+++ b/tmp/factory2/models/UserModelInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models;
+
+interface UserModelInterface
+{
+  // ユーザー情報を取得する
+  public function find(int $UserId);
+}

--- a/tmp/factory2/models/production/BlogModel.php
+++ b/tmp/factory2/models/production/BlogModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models\Production;
+
+use MyApplication\Models\BlogModelInterface;
+
+require_once dirname(__FILE__) . '/../BlogModelInterface.php';
+
+class BlogModel implements BlogModelInterface
+{
+  // データベースからブログ記事を取得する
+  public function find(int $blogId)
+  {
+    echo 'ID:' . $blogId . 'を持つブログ記事を取得しました。' . PHP_EOL;
+  }
+}

--- a/tmp/factory2/models/production/UserModel.php
+++ b/tmp/factory2/models/production/UserModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models\Production;
+
+use MyApplication\Models\UserModelInterface;
+
+require_once dirname(__FILE__) . '/../UserModelInterface.php';
+
+class UserModel implements UserModelInterface
+{
+  // データベースからユーザー情報を取得する
+  public function find(int $userId)
+  {
+    echo 'ID:' . $userId . 'を持つユーザー情報を取得しました。' . PHP_EOL;
+  }
+}

--- a/tmp/factory2/models/testing/TestBlogModel.php
+++ b/tmp/factory2/models/testing/TestBlogModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models\Testing;
+
+use MyApplication\Models\BlogModelInterface;
+
+require_once dirname(__FILE__) . '/../UserModelInterface.php';
+class TestBlogModel implements BlogModelInterface
+{
+  // データベースからブログ記事を取得する
+  public function find(int $blogId)
+  {
+    echo 'ID:' . $blogId . 'を持つブログ記事(テスト用の固定値)を取得しました。' . PHP_EOL;
+  }
+}

--- a/tmp/factory2/models/testing/TestUserModel.php
+++ b/tmp/factory2/models/testing/TestUserModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApplication\Models\Testing;
+
+use MyApplication\Models\UserModelInterface;
+
+require_once dirname(__FILE__) . '/../UserModelInterface.php';
+
+class TestUserModel implements UserModelInterface
+{
+  // データベースからユーザー情報を取得する
+  public function find(int $userId)
+  {
+    echo 'ID:' . $userId . 'を持つユーザー情報(テスト用の固定値)を取得しました。' . PHP_EOL;
+  }
+}


### PR DESCRIPTION
Factoryパターンとして、具象クラスのDatabaseModelFactoryクラスおよびTestDatabaseModelFactoryを切り替えられるように抽象クラスのAbstractDatabaseModelFactoryクラスを作成。また、上記2つのFactoryクラスにてそれぞれ生成されるインスタンス(今回はUserModel,BlogModelおよびTestUserModel,TestBlogModel)に対して、UserModelInterfaceおよびBlogModelInterfaceを実装させております。これによって、BlogController.phpのメインルーチンにて、テスト環境と本番環境で使用するDatabasemodelFactoryの切り替えが可能な仕様となりました。