### PR TITLE
.envファイルの読み込み処理をdbConnect()内に移動しました。

### DIFF
--- a/companies/companies_table.php
+++ b/companies/companies_table.php
@@ -2,11 +2,10 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
-$dotenv->load();
-
 function dbConnect(): PDO
 {
+  $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/..');
+  $dotenv->load();
   try {
     $pdo = new PDO('mysql:host=' . $_ENV['DB_HOST'] . ';dbname=' . $_ENV['DB_DATABASE'] .  '; charset=utf8mb4', $_ENV['DB_USER'],  $_ENV['DB_PASSWORD']);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
環境変数をdbConnect()でしか使用しないため、.envの読み込み処理をdbConnect()内に移動しました。