### PR TITLE
createCompanyメソッドにて$company['founder']の値セットの誤りを修正。

### DIFF
--- a/companies/create.php
+++ b/companies/create.php
@@ -9,7 +9,7 @@ function createCompany($pdo, $company): void
     $statement = $pdo->prepare('INSERT INTO companies (name, establishment_date, founder) VALUES (:name, :establishment_date, :founder)');
     $statement->bindValue(':name', $company['name'], PDO::PARAM_STR);
     $statement->bindValue(':establishment_date', $company['establishment_date'], PDO::PARAM_STR);
-    $statement->bindValue(':founder', $company['name'], PDO::PARAM_STR);
+    $statement->bindValue(':founder', $company['founder'], PDO::PARAM_STR);
     $statement->execute();
     $pdo->commit();
   } catch (PDOException $e) {
@@ -65,5 +65,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // もしエラーがあれば下記ページを表示
-
-include 'views/form.php';
+$title = '会社情報の登録';
+$content = __DIR__ . "/views/form.php";
+include 'views/layout.php';


### PR DESCRIPTION
・createCompanyメソッドにて$company['founder']の値セットが誤って$company['name']となっていたので修正しました。
・バリデーション処理にてエラーがあった場合、読み込み元をform.phpからlayout.phpに変更。それに伴い、layout.phpにて読み込む$contentと$titleを定義しました。