### PR TITLE
index.phpにて会社情報の一覧が表示されるようにしました。

### DIFF
--- a/companies/views/index.php
+++ b/companies/views/index.php
@@ -1,18 +1,41 @@
+<?php
+
+require_once __DIR__ . '../../lib/pdo.php';
+
+// 会社情報を取得するメソッド
+function listCompanies($pdo): array
+{
+  $results = [];
+  $statement = $pdo->prepare('SELECT name, establishment_date, founder FROM companies');
+  $statement->execute();
+  // assoc処理を記述していく
+  while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+    $results[] = $row;
+  }
+  return $results;
+}
+
+// メインルーチン
+$pdo = dbConnect();
+$companies = listCompanies($pdo);
+
+?>
+
 <body>
   <h1>会社情報の一覧</h1>
   <a href="new.php">会社情報を登録する</a>
   <main>
-    <section>
-      <h2>株式会社メルカリ</h2>
-      <div>
-        創業:2013年 | 代表:山田進太郎
-      </div>
-    </section>
-    <section>
-      <h2>株式会社メルカリ</h2>
-      <div>
-        創業:2013年 | 代表:山田進太郎
-      </div>
-    </section>
+    <?php if (count($companies) > 0) : ?>
+      <?php foreach ($companies as $company) : ?>
+        <section>
+          <h2><?php echo $company['name']; ?></h2>
+          <div>
+            創業:<?php echo $company['establishment_date']; ?>年&nbsp;|&nbsp;代表:<?php echo $company['founder']; ?>
+          </div>
+        </section>
+      <?php endforeach; ?>
+    <?php else : ?>
+      <p>会社情報が登録されておりません。</p>
+    <?php endif; ?>
   </main>
 </body>


### PR DESCRIPTION
index.phpにて会社情報の一覧がデータベースに登録されている内容ごとに表示されるようにしました。

・dbConnectメソッドにてデータベースに接続。
・listCompaniesメソッドにてデータベースから情報を取得し、連想配列にして$resultsとして連想配列を返します。
・listCompaniesメソッドにて取得した連想配列($companies)を<main>タグ内にてforerachで回し、データベースに登録された会社情報ごとに表示させております。
・この際、if条件にて条件分岐させて、データベースに会社情報が未登録の場合は”会社情報が登録されておりません。”と表示させております。
